### PR TITLE
.gitignore修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+
+public/uploads/*


### PR DESCRIPTION
# WHAT
.gitignore修正。

# WHY
public/uploads以下に追加される画像ファイルをコミットされないようにするため。